### PR TITLE
[TASK] Add option for marker cluster style array

### DIFF
--- a/Classes/Domain/Model/Map.php
+++ b/Classes/Domain/Model/Map.php
@@ -147,6 +147,12 @@ class Map extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
      */
     protected $markerClusterSize;
     /**
+     * markerClusterStyle
+     *
+     * @var \string
+     */
+    protected $markerClusterStyle;
+    /**
      * markerSearch
      *
      * @var boolean
@@ -749,6 +755,27 @@ class Map extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
     public function setMarkerClusterSize($markerClusterSize)
     {
         $this->markerClusterSize = $markerClusterSize;
+    }
+
+    /**
+     * Returns the markerClusterStyle
+     *
+     * @return \string $markerClusterStyle
+     */
+    public function getMarkerClusterStyle()
+    {
+        return $this->markerClusterStyle;
+    }
+
+    /**
+     * Sets the markerClusterStyle
+     *
+     * @param \string $markerClusterStyle
+     * @return void
+     */
+    public function setMarkerClusterStyle($markerClusterStyle)
+    {
+        $this->markerClusterStyle = $markerClusterStyle;
     }
 
     /**

--- a/Configuration/TCA/tx_gomapsext_domain_model_map.php
+++ b/Configuration/TCA/tx_gomapsext_domain_model_map.php
@@ -31,7 +31,7 @@ return array(
 		'showRecordFieldList' => 'sys_language_uid, l10n_parent, l10n_diffsource, hidden, title, tooltip_title,
 		                          class, width, height, zoom, zoom_min, zoom_max, addresses, kml_url, kml_local, show_route,
 		                          calc_route, scroll_zoom, draggable, double_click_zoom, marker_cluster,
-		                          marker_cluster_zoom, marker_cluster_size, marker_search, default_type,
+		                          marker_cluster_zoom, marker_cluster_size, marker_cluster_style, marker_search, default_type,
 		                          pan_control, scale_control, streetview_control, zoom_control, zoom_control_type,
 		                          map_type_control, map_types, styled_map_name, styled_map_code',
 	),
@@ -57,7 +57,7 @@ return array(
 	),
 	'palettes' => array(
         'address_interaction' => array('showitem' => 'marker_search, show_addresses, show_categories'),
-		'cluster' => array('showitem' => 'marker_cluster, --linebreak--, marker_cluster_zoom, marker_cluster_size'),
+		'cluster' => array('showitem' => 'marker_cluster, --linebreak--, marker_cluster_zoom, marker_cluster_size, --linebreak--, marker_cluster_style'),
 		'controls' => array('showitem' => 'pan_control, scale_control, streetview_control'),
 		'interaction' => array('showitem' => 'scroll_zoom, draggable, double_click_zoom'),
 		'kml' => array('showitem' => 'kml_url, --linebreak--, kml_preserve_viewport, kml_local'),
@@ -339,6 +339,16 @@ return array(
 				'type' => 'input',
 				'size' => 4,
 				'eval' => 'int'
+			),
+		),
+		'marker_cluster_style' => array(
+			'exclude' => 1,
+			'label' => 'LLL:EXT:go_maps_ext/Resources/Private/Language/locallang_db.xlf:tx_gomapsext_domain_model_map.marker_cluster_style',
+			'config' => array(
+				'type' => 'text',
+				'cols' => 40,
+				'rows' => 10,
+				'eval' => 'trim'
 			),
 		),
 		'marker_search' => array(

--- a/Resources/Private/Language/de.locallang_db.xlf
+++ b/Resources/Private/Language/de.locallang_db.xlf
@@ -229,6 +229,10 @@
 			<source>Max zoom level</source>
 			<target>Max. Zoom-Level</target>
 		</trans-unit>
+		<trans-unit id="tx_gomapsext_domain_model_map.marker_cluster_style">
+			<source>Marker Cluster style code</source>
+			<target>Marker Cluster Style Code</target>
+		</trans-unit>
 		<trans-unit id="tx_gomapsext_domain_model_map.marker_search" approved="yes">
 			<source>Marker Search</source>
 			<target>Marker Suche</target>

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -174,6 +174,9 @@
 		<trans-unit id="tx_gomapsext_domain_model_map.marker_cluster_zoom">
 			<source>Max zoom level</source>
 		</trans-unit>
+		<trans-unit id="tx_gomapsext_domain_model_map.marker_cluster_style">
+			<source>Marker Cluster style code</source>
+		</trans-unit>
 		<trans-unit id="tx_gomapsext_domain_model_map.marker_search">
 			<source>Marker Search</source>
 		</trans-unit>

--- a/Resources/Private/Partials/Map/Assign.html
+++ b/Resources/Private/Partials/Map/Assign.html
@@ -31,6 +31,14 @@
             markerCluster: {f:if(condition:"{map.markerCluster}", then:"1", else:"0")},
             markerClusterZoom: {f:if(condition:"{map.markerClusterZoom} > 0", then:"{map.markerClusterZoom}", else:"null")},
             markerClusterSize: {f:if(condition:"{map.markerClusterSize} > 0", then:"{map.markerClusterSize}", else:"null")},
+            <f:if condition="{map.markerClusterStyle}">
+                <f:then>
+                    markerClusterStyle: <f:format.html parseFuncTSPath="">{map.markerClusterStyle}</f:format.html>,
+                </f:then>
+                <f:else>
+                    markerClusterStyle: '',
+                </f:else>
+            </f:if>
             markerSearch: {f:if(condition:"{map.markerSearch}", then:"1", else:"0")},
             defaultType: {map.defaultType},
             panControl: {f:if(condition:"{map.panControl}", then:"1", else:"0")},

--- a/Resources/Public/Scripts/jquery.gomapsext.js
+++ b/Resources/Public/Scripts/jquery.gomapsext.js
@@ -361,6 +361,7 @@
                 }
                 $element.markerCluster = new MarkerClusterer(this.map, this.markers, {
                     imagePath: 'https://googlemaps.github.io/js-marker-clusterer/images/m',
+                    styles: gme.mapSettings.markerClusterStyle,
                     maxZoom: gme.mapSettings.markerClusterZoom,
                     gridSize: gme.mapSettings.markerClusterSize
                 });

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -80,6 +80,7 @@ CREATE TABLE tx_gomapsext_domain_model_map (
 	marker_cluster tinyint(1) unsigned DEFAULT '0' NOT NULL,
 	marker_cluster_zoom int(11) DEFAULT '0' NOT NULL,
 	marker_cluster_size int(11) DEFAULT '0' NOT NULL,
+	marker_cluster_style text NOT NULL,
 	marker_search tinyint(1) unsigned DEFAULT '0' NOT NULL,
 	default_type int(11) DEFAULT '0' NOT NULL,
 	pan_control tinyint(1) unsigned DEFAULT '0' NOT NULL,


### PR DESCRIPTION
Add an option to customize the styling array (url, size, color, font
size) of the marker cluster in the backend the same way as the map styles