### PR TITLE
Possibility to use address records from cur pid

### DIFF
--- a/Classes/Controller/MapController.php
+++ b/Classes/Controller/MapController.php
@@ -119,7 +119,11 @@ class MapController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionController {
 		// find addresses
 		$pid = $this->settings['storagePid'];
 		if ($pid) {
-			$addresses = $this->addressRepository->findAllAddresses($map, $pid);
+			if ($pid == 'this'){
+				$addresses = $this->addressRepository->findAllAddresses($map, $GLOBALS['TSFE']->id);
+			} else {
+				$addresses = $this->addressRepository->findAllAddresses($map, $pid);
+			}
 		} else {
 			$addresses = $map->getAddresses();
 		}


### PR DESCRIPTION
The settings.storagePid is used to define a pid with address records.
Now additionally you can set the constant to "this"

Example:
plugin.tx_gomapsext.settings.storagePid = this

and it will use always the current page pid like a storagePid to get the address records.