### PR TITLE
[FEATURE] Add possibility to center the map via map-record

### DIFF
--- a/Classes/Domain/Model/Map.php
+++ b/Classes/Domain/Model/Map.php
@@ -259,6 +259,18 @@ class Map extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity {
 	 * @var \array
 	 */
 	protected $unitSystems = [];
+    /**
+     * latitude
+     *
+     * @var \float
+     */
+    protected $latitude;
+    /**
+     * longitude
+     *
+     * @var \float
+     */
+    protected $longitude;
 
 	/**
 	 * __construct
@@ -1129,4 +1141,43 @@ class Map extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity {
 
 		return $unitSystems;
 	}
+
+    /**
+     * Returns the latitude
+     *
+     * @return \float $latitude
+     */
+    public function getLatitude() {
+        return $this->latitude;
+    }
+
+    /**
+     * Sets the latitude
+     *
+     * @param \float $latitude
+     * @return void
+     */
+    public function setLatitude($latitude) {
+        $this->latitude = $latitude;
+    }
+
+    /**
+     * Returns the longitude
+     *
+     * @return \float $longitude
+     */
+    public function getLongitude() {
+        return $this->longitude;
+    }
+
+    /**
+     * Sets the longitude
+     *
+     * @param \float $longitude
+     * @return void
+     */
+    public function setLongitude($longitude) {
+        $this->longitude = $longitude;
+    }
+
 }

--- a/Configuration/TCA/tx_gomapsext_domain_model_map.php
+++ b/Configuration/TCA/tx_gomapsext_domain_model_map.php
@@ -24,7 +24,7 @@ return [
 	],
 	'interface' => [
 		'showRecordFieldList' => 'sys_language_uid, l10n_parent, l10n_diffsource, hidden, title, tooltip_title,
-		                          class, width, height, zoom, zoom_min, zoom_max, addresses, kml_url, kml_local, show_route,
+		                          class, width, height, zoom, zoom_min, zoom_max, latitude, longitude, addresses, kml_url, kml_local, show_route,
 		                          calc_route, scroll_zoom, draggable, double_click_zoom, marker_cluster,
 		                          marker_cluster_zoom, marker_cluster_size, marker_cluster_style, marker_search, default_type,
 		                          pan_control, scale_control, streetview_control, zoom_control, zoom_control_type,
@@ -35,6 +35,7 @@ return [
 			'showitem' => 'title,
 					--palette--;LLL:EXT:go_maps_ext/Resources/Private/Language/locallang_db.xlf:tx_gomapsext_domain_model_map.palettes.size;size,
 					--palette--;LLL:EXT:go_maps_ext/Resources/Private/Language/locallang_db.xlf:tx_gomapsext_domain_model_map.palettes.zoom;zoom, addresses,
+					--palette--;LLL:EXT:go_maps_ext/Resources/Private/Language/locallang_db.xlf:tx_gomapsext_domain_model_map.palettes.coordinates;coordinates,
 					--palette--;LLL:EXT:go_maps_ext/Resources/Private/Language/locallang_db.xlf:tx_gomapsext_domain_model_map.palettes.kml;kml,
 					--div--;LLL:EXT:go_maps_ext/Resources/Private/Language/locallang_db.xlf:tx_gomapsext_domain_model_map.tab.display,
 					default_type,
@@ -57,6 +58,7 @@ return [
 		'address_interaction' => ['showitem' => 'marker_search, show_addresses, show_categories'],
 		'cluster' => ['showitem' => 'marker_cluster, --linebreak--, marker_cluster_zoom, marker_cluster_size'],
 		'controls' => ['showitem' => 'pan_control, scale_control, streetview_control'],
+        'coordinates' => ['showitem' => 'latitude, longitude'],
 		'interaction' => ['showitem' => 'scroll_zoom, draggable, double_click_zoom'],
 		'kml' => ['showitem' => 'kml_url, --linebreak--, kml_preserve_viewport, kml_local'],
 		'map_control' => ['showitem' => 'map_type_control, --linebreak--, map_types'],
@@ -580,5 +582,23 @@ return [
 				'eval' => 'trim'
 			],
 		],
+        'latitude' => [
+            'exclude' => 0,
+            'label' => 'LLL:EXT:go_maps_ext/Resources/Private/Language/locallang_db.xlf:tx_gomapsext_domain_model_map.latitude',
+            'config' => [
+                'type' => 'input',
+                'size' => 30,
+                'eval' => 'trim,Clickstorm\\GoMapsExt\\Evaluation\\Double6Evaluator'
+            ],
+        ],
+        'longitude' => [
+            'exclude' => 0,
+            'label' => 'LLL:EXT:go_maps_ext/Resources/Private/Language/locallang_db.xlf:tx_gomapsext_domain_model_map.longitude',
+            'config' => [
+                'type' => 'input',
+                'size' => 30,
+                'eval' => 'trim,Clickstorm\\GoMapsExt\\Evaluation\\Double6Evaluator'
+            ],
+        ],
 	],
 ];

--- a/Resources/Private/Language/de.locallang_csh_tx_gomapsext_domain_model_map.xlf
+++ b/Resources/Private/Language/de.locallang_csh_tx_gomapsext_domain_model_map.xlf
@@ -154,6 +154,14 @@
 			<source>The minimum zoom level which will be displayed on the map. If omitted, or set to null, the minimum zoom from the current map type is used instead.</source>
 			<target>Der minimale Zoomstufe, in der die Karte angezeigt wird. Wenn nicht angegeben oder auf Null gesetzt, wird der minimale Zoom vom aktuellen Kartentyp verwendet.</target>
 		</trans-unit>
+		<trans-unit id="latitude.description" approved="yes">
+			<source>Insert the latitude of the point on which your map should be centered at the page load.</source>
+			<target>Breitengrad des Punktes, welcher beim Seitenaufruf der Karte das Zentrum bildet.</target>
+		</trans-unit>
+		<trans-unit id="longitude.description" approved="yes">
+			<source>Insert the longitude of the point on which your map should be centered at the page load.</source>
+			<target>Längengrad des Punktes, welcher beim Seitenaufruf der Karte das Zentrum bildet.</target>
+		</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Resources/Private/Language/de.locallang_db.xlf
+++ b/Resources/Private/Language/de.locallang_db.xlf
@@ -277,6 +277,10 @@
 			<source>Zoom settings</source>
 			<target>Zoom Einstellungen</target>
 		</trans-unit>
+		<trans-unit id="tx_gomapsext_domain_model_map.palettes.coordinates" approved="yes">
+			<source>Default card cutout</source>
+			<target>Standard Kartenausschnitt</target>
+		</trans-unit>
 		<trans-unit id="tx_gomapsext_domain_model_map.pan_control" approved="yes">
 			<source>Pan control</source>
 			<target>Zeige Schwenksteuerung</target>
@@ -416,6 +420,14 @@
 		<trans-unit id="tx_gomapsext_domain_model_map.zoom_min" approved="yes">
 			<source>Zoom min</source>
 			<target>Zoom min</target>
+		</trans-unit>
+		<trans-unit id="tx_gomapsext_domain_model_map.latitude" approved="yes">
+			<source>Latitude</source>
+			<target>Breitengrad</target>
+		</trans-unit>
+		<trans-unit id="tx_gomapsext_domain_model_map.longitude" approved="yes">
+			<source>Longitude</source>
+			<target>Längengrad</target>
 		</trans-unit>
 		</body>
 	</file>

--- a/Resources/Private/Language/locallang_csh_tx_gomapsext_domain_model_map.xlf
+++ b/Resources/Private/Language/locallang_csh_tx_gomapsext_domain_model_map.xlf
@@ -124,6 +124,12 @@
 		<trans-unit id="zoom_min.description">
 			<source>The minimum zoom level which will be displayed on the map. If omitted, or set to null, the minimum zoom from the current map type is used instead.</source>
 		</trans-unit>
+		<trans-unit id="latitude.description">
+			<source>Insert the latitude of the point on which your map should be centered at the page load.</source>
+		</trans-unit>
+		<trans-unit id="longitude.description">
+			<source>Insert the longitude of the point on which your map should be centered at the page load.</source>
+		</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -210,6 +210,9 @@
 		<trans-unit id="tx_gomapsext_domain_model_map.palettes.zoom">
 			<source>Zoom settings</source>
 		</trans-unit>
+		<trans-unit id="tx_gomapsext_domain_model_map.palettes.coordinates">
+			<source>Default card cutout</source>
+		</trans-unit>
 		<trans-unit id="tx_gomapsext_domain_model_map.pan_control">
 			<source>Pan control</source>
 		</trans-unit>
@@ -317,6 +320,12 @@
 		</trans-unit>
 		<trans-unit id="tx_gomapsext_domain_model_map.zoom_min">
 			<source>Zoom min</source>
+		</trans-unit>
+		<trans-unit id="tx_gomapsext_domain_model_map.latitude">
+			<source>Latitude</source>
+		</trans-unit>
+		<trans-unit id="tx_gomapsext_domain_model_map.longitude">
+			<source>Longitude</source>
 		</trans-unit>
 		</body>
 	</file>

--- a/Resources/Private/Partials/Map/Assign.html
+++ b/Resources/Private/Partials/Map/Assign.html
@@ -22,6 +22,8 @@
     zoom: {f:if(condition:"{map.zoom}", then:"{map.zoom}", else:"0")},
     minZoom: {f:if(condition:"{map.zoomMin}", then:"{map.zoomMin}", else:"0")},
     maxZoom: {f:if(condition:"{map.zoomMax}", then:"{map.zoomMax}", else:"0")},
+    lat: {f:if(condition:"{map.latitude} > 0", then: "{map.latitude}", else:"0")},
+    lng: {f:if(condition:"{map.longitude} > 0", then: "{map.longitude}", else:"0")},
     kmlUrl: '{map.kmlUrl}',
     kmlPreserveViewport: {f:if(condition:"{map.kmlPreserveViewport}", then:"true", else:"false")},
     kmlLocal: {f:if(condition:"{map.kmlLocal}", then:"1", else:"0")},

--- a/Resources/Public/Scripts/jquery.gomapsext.js
+++ b/Resources/Public/Scripts/jquery.gomapsext.js
@@ -349,6 +349,9 @@
 
             if ($element.data("center")) {
                 _map.setCenter($element.data("center"));
+            } else if(gme.mapSettings.lat != 0 && gme.mapSettings.lng != 0) {
+                _map.setCenter(new google.maps.LatLng(gme.mapSettings.lat, gme.mapSettings.lng));
+                _map.setZoom(gme.mapSettings.zoom);
             } else {
                 _map.fitBounds(this.bounds);
             }

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -97,6 +97,8 @@ CREATE TABLE tx_gomapsext_domain_model_map (
 	unit_system int(11) DEFAULT '0' NOT NULL,
 	styled_map_name varchar(255) DEFAULT '' NOT NULL,
 	styled_map_code text NOT NULL,
+	longitude double(11,6) DEFAULT '0.000000' NOT NULL,
+	latitude double(11,6) DEFAULT '0.000000' NOT NULL,
 	
 	tstamp int(11) unsigned DEFAULT '0' NOT NULL,
 	crdate int(11) unsigned DEFAULT '0' NOT NULL,


### PR DESCRIPTION
Add latitude and longitude properties to the „map“ record. With this
two options, you are able to manually set the center of the map.