### PR TITLE
[FEATURE] update TCA sys_language_uid setting for address and map (use special=languages config)

### DIFF
--- a/Configuration/TCA/tx_gomapsext_domain_model_address.php
+++ b/Configuration/TCA/tx_gomapsext_domain_model_address.php
@@ -58,14 +58,17 @@ return [
 			'config' => [
 				'type' => 'select',
 				'renderType' => 'selectSingle',
-				'foreign_table' => 'sys_language',
-				'foreign_table_where' => 'ORDER BY sys_language.title',
+				'special' => 'languages',
 				'items' => [
-					['LLL:EXT:lang/locallang_general.xlf:LGL.allLanguages', -1],
-					['LLL:EXT:lang/locallang_general.xlf:LGL.default_value', 0]
+					[
+						'LLL:EXT:lang/locallang_general.xlf:LGL.allLanguages',
+						-1,
+						'flags-multiple'
+					]
 				],
+				'default' => 0,
 			],
-		],
+        ],
 		'l10n_parent' => [
 			'displayCond' => 'FIELD:sys_language_uid:>:0',
 			'exclude' => 1,

--- a/Configuration/TCA/tx_gomapsext_domain_model_map.php
+++ b/Configuration/TCA/tx_gomapsext_domain_model_map.php
@@ -77,14 +77,17 @@ return [
 			'config' => [
 				'type' => 'select',
 				'renderType' => 'selectSingle',
-				'foreign_table' => 'sys_language',
-				'foreign_table_where' => 'ORDER BY sys_language.title',
+				'special' => 'languages',
 				'items' => [
-					['LLL:EXT:lang/locallang_general.xlf:LGL.allLanguages', -1],
-					['LLL:EXT:lang/locallang_general.xlf:LGL.default_value', 0]
+					[
+						'LLL:EXT:lang/locallang_general.xlf:LGL.allLanguages',
+						-1,
+						'flags-multiple'
+					]
 				],
+				'default' => 0,
 			],
-		],
+        ],
 		'l10n_parent' => [
 			'displayCond' => 'FIELD:sys_language_uid:>:0',
 			'exclude' => 1,


### PR DESCRIPTION
Hi Marc,

I've updated the TCA sys_language_uid settings because the current settings can cause failure in some cases. The current language settings in TCA is "all language". If I change this to "default language", this failure can not happen.
Same language settings exists e.g. in news extension, see: 
https://github.com/georgringer/news/blob/master/Configuration/TCA/tx_news_domain_model_news.php 

Regards,
János