### PR TITLE
[TASK] Set default value for info_window_content

### DIFF
--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -17,7 +17,7 @@ CREATE TABLE tx_gomapsext_domain_model_address (
 	image_size          tinyint(1) unsigned DEFAULT '0'        NOT NULL,
 	image_width         int(11)             DEFAULT '0'        NOT NULL,
 	image_height        int(11)             DEFAULT '0'        NOT NULL,
-	info_window_content text                                   NOT NULL,
+	info_window_content text                DEFAULT ''         NOT NULL,
 	info_window_link    int(11)             DEFAULT '0'        NOT NULL,
 	info_window_images  int(11) unsigned                       NOT NULL default '0',
 	close_by_click      tinyint(1) unsigned DEFAULT '0'        NOT NULL,


### PR DESCRIPTION
I get an error in  TYPO3 10.4.20 when I create a address with a info_window_content, due to a missing default value on database level for the column "info_window_content".