### PR TITLE
[BUGFIX] Avoid null pointer exception

### DIFF
--- a/Classes/Controller/MapController.php
+++ b/Classes/Controller/MapController.php
@@ -181,6 +181,10 @@ class MapController extends ActionController
         // get current map
         /* @var Map $map */
         $map = $map ?? $this->mapRepository->findByUid($this->settings['map']);
+        
+        if (is_null($map)) {
+            return;
+        }
 
         // find addresses
         $addresses = $map->getAddresses();

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -223,6 +223,10 @@
 				<source><![CDATA[Update by Position]]></source>
 				<target><![CDATA[Aktualisiere mit Position]]></target>
 			</trans-unit>
+			<trans-unit id="show_nomapfound" resname="show_nomapfound">
+				<source><![CDATA[No map available.]]></source>
+				<target><![CDATA[Keine Karte vorhanden.]]></target>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -168,6 +168,9 @@
 			<trans-unit id="update_by_position" resname="update_by_position">
 				<source><![CDATA[Update by Position]]></source>
 			</trans-unit>
+			<trans-unit id="show_nomapfound" resname="show_nomapfound">
+				<source><![CDATA[No map available.]]></source>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Resources/Private/Language/pl.locallang.xlf
+++ b/Resources/Private/Language/pl.locallang.xlf
@@ -208,6 +208,10 @@
 				<source><![CDATA[Search]]></source>
 				<target><![CDATA[Szukaj]]></target>
 			</trans-unit>
+			<trans-unit id="show_nomapfound" resname="show_nomapfound">
+				<source><![CDATA[No map available.]]></source>
+				<target><![CDATA[Brak dostępnej mapy.]]></target>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Resources/Private/Templates/Map/Show.html
+++ b/Resources/Private/Templates/Map/Show.html
@@ -2,21 +2,30 @@
 <f:layout name="Default"/>
 <!-- Keep the id and the js-classes -->
 <f:section name="Main">
-    <f:if condition="{settings.preview.enabled}">
-        <f:render partial="Preview" arguments="{_all}"/>
+    <f:if condition="{map}">
+        <f:then>
+            <f:if condition="{settings.preview.enabled}">
+                <f:render partial="Preview" arguments="{_all}"/>
+            </f:if>
+            <div class="js-gme-container">
+                <f:if condition="{map.showForm}">
+                    <f:render partial="Map/Form" arguments="{_all}"/>
+                </f:if>
+                <div class="js-map" id="gme-{map.uid}"></div>
+                <f:render partial="Map/Assign" arguments="{_all}"/>
+                <f:if condition="{map.showCategories}">
+                    <f:render partial="Map/Categories" arguments="{_all}"/>
+                </f:if>
+                <f:if condition="{map.showAddresses}">
+                    <f:render partial="Map/Addresses" arguments="{_all}"/>
+                </f:if>
+            </div>
+        </f:then>
+        <f:else>
+            <div class="no-map-found">
+                <f:translate key="show_nomapfound" />
+            </div>
+        </f:else>
     </f:if>
-    <div class="js-gme-container">
-        <f:if condition="{map.showForm}">
-            <f:render partial="Map/Form" arguments="{_all}"/>
-        </f:if>
-        <div class="js-map" id="gme-{map.uid}"></div>
-        <f:render partial="Map/Assign" arguments="{_all}"/>
-        <f:if condition="{map.showCategories}">
-            <f:render partial="Map/Categories" arguments="{_all}"/>
-        </f:if>
-        <f:if condition="{map.showAddresses}">
-            <f:render partial="Map/Addresses" arguments="{_all}"/>
-        </f:if>
-    </div>
 </f:section>
 </html>


### PR DESCRIPTION
If the referenced map has been disabled, you will get the error "Call to a member function getAddresses() on null". This can be fixed by checking if a map was found before proceeding. I also updated the fluid template and added new labels accordingly.