### PR TITLE
Add zoom on focusAddress with clusters and fix search of hidden addresses

### DIFF
--- a/Resources/Public/Scripts/gomapsext.js
+++ b/Resources/Public/Scripts/gomapsext.js
@@ -571,8 +571,10 @@ class GoMapsExtController {
               (index === 'title' || index === 'infoWindowContent') &&
               submitValue !== '') {
               if (val.toLowerCase().includes(submitValue)) {
-                _this.focusAddress(_this.markers[i].uid, $element, gme);
-                notFound = false;
+                if (_this.markers[i].visible) {
+                  _this.focusAddress(_this.markers[i].uid, $element, gme);
+                  notFound = false;
+                }
               }
             }
           });

--- a/Resources/Public/Scripts/gomapsext.js
+++ b/Resources/Public/Scripts/gomapsext.js
@@ -184,6 +184,10 @@ class GoMapsExtController {
     });
     if (element.markerCluster) {
       element.markerCluster.repaint();
+
+      if (gme.mapSettings.markerClusterZoom) {
+        this.map.setZoom(gme.mapSettings.markerClusterZoom + 1);
+      }
     }
   }
 


### PR DESCRIPTION
#113 

Add a zoom on focusAddress only when clusters and clusterZoom are set to avoid infoWindow being hidden behind a cluster.

Also fix an issue to show only visible addresses when searching while some categories are deselected.